### PR TITLE
Update CsvBulkLoadTool.java

### DIFF
--- a/phoenix-core/src/main/java/org/apache/phoenix/mapreduce/CsvBulkLoadTool.java
+++ b/phoenix-core/src/main/java/org/apache/phoenix/mapreduce/CsvBulkLoadTool.java
@@ -331,7 +331,7 @@ public class CsvBulkLoadTool extends Configured implements Tool {
     static void configureOptions(CommandLine cmdLine, List<ColumnInfo> importColumns,
             Configuration conf) {
 
-        char delimiterChar = ',';
+        char delimiterChar = '\t';
         if (cmdLine.hasOption(DELIMITER_OPT.getOpt())) {
             String delimString = cmdLine.getOptionValue(DELIMITER_OPT.getOpt());
             if (delimString.length() != 1) {


### PR DESCRIPTION
in real csvbulkload using,delimiter of the data is always  ' \t', But phoenix only support single char as delimiter and default is ',', so set the default delimiter to '\t' .